### PR TITLE
Improve default SSL config, allow local overrides

### DIFF
--- a/appliance-root/opt/noit/prod/etc/circonus-listeners-site.conf
+++ b/appliance-root/opt/noit/prod/etc/circonus-listeners-site.conf
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf8"?>
+<sitelisteners>
 <!--
   Configure additional listeners, possibly with a different
   SSL configuration as well.  Circonus will only connect to
@@ -34,3 +35,4 @@
     </config>
   </listener>
 -->
+</sitelisteners>

--- a/appliance-root/opt/noit/prod/etc/circonus-listeners.conf
+++ b/appliance-root/opt/noit/prod/etc/circonus-listeners.conf
@@ -33,5 +33,5 @@
     </config>
   </listener>
 
-  <include file="circonus-listeners-site.conf" snippet="true"/>
+  <include file="circonus-listeners-site.conf"/>
 </listeners>


### PR DESCRIPTION
Default SSL-enabled 43191 listener now enforces server preference
for cipher ordering and uses a better cipher list. This list uses
only ciphers that have forward-secrecy properties, and orders them
first by security and then by performance where security is
equivalent.

If this causes issues for applications that are using the default
listener for push checks, operators may configure additional listeners
using the new circonus-listeners-site.conf file, which has an example
and comments explaining motivation. The site file gets included at the
end of circonus-listeners.conf and will be flagged as locally
modifiable in packaging.

Note that we would like to have included ECDHE ciphers in the default
string, but libmtev does not support elliptic-curve ciphers yet. When
it does, we will update the default cipher list to include them,
as they are faster than non-EC DHE.
