### PR TITLE
supress HWLOC error

### DIFF
--- a/appliance-root/opt/napp/bin/provtool
+++ b/appliance-root/opt/napp/bin/provtool
@@ -4,6 +4,8 @@ LUAMTEV=/opt/circonus/bin/luamtev
 CONF=/opt/noit/prod/etc/provtool.conf
 USER=broker
 GROUP=broker
+HWLOC_HIDE_ERRORS=1
+export HWLOC_HIDE_ERRORS
 
 set -o allexport
 if [ -r /opt/noit/prod/etc/noit.env ]; then


### PR DESCRIPTION
in Centos running on kvm with multiple cpu HWLOC generates a warning.  HWLOC_HIDE_ERRORS=1 will suppress that warning.
