### PR TITLE
Escape the configured api url so search will work with non-word chara…

### DIFF
--- a/appliance-root/opt/napp/noitweb/broker.lua
+++ b/appliance-root/opt/napp/noitweb/broker.lua
@@ -51,7 +51,8 @@ function fetch_url(url)
   end
 
   local headers = { Host = host }
-  if string.find(url, circonus_api_url()) == 1 then
+  local escaped_circonus_api_url = circonus_api_url():gsub("([^%w])", "%%%1")
+  if string.find(url, escaped_circonus_api_url) == 1 then
     headers["X-Circonus-Auth-Token"] = circonus_api_token()
     headers["X-Circonus-App-Name"] = "broker-provision"
     headers["Accept"] = "application/json"

--- a/appliance-root/opt/napp/noitweb/prov.lua
+++ b/appliance-root/opt/napp/noitweb/prov.lua
@@ -280,7 +280,8 @@ function HTTP(method, url, payload, silent, _pp)
   local headers = {}
   local in_headers = {}
 
-  if string.find(url, circonus_api_url()) == 1 then
+  local escaped_circonus_api_url = circonus_api_url():gsub("([^%w])", "%%%1")
+  if string.find(url, escaped_circonus_api_url) == 1 then
     headers["X-Circonus-Auth-Token"] = API_TOKEN
     headers["X-Circonus-App-Name"] = "broker-provision"
   end
@@ -333,7 +334,7 @@ function HTTP(method, url, payload, silent, _pp)
   local rv = client:do_request(method, uri, headers, payload, "1.1")
   client:get_response(1024000)
 
-  if string.find(url, circonus_api_url()) == 1 then
+  if string.find(url, escaped_circonus_api_url) == 1 then
     if client.code == 403 then
       _F("Permission denied! (bad CIRCONUS_AUTH_TOKEN?)\n")
     end


### PR DESCRIPTION
…cters

For example if someone has a hyphen in their api url:

http://dchristian-dev11.dev.circonus.net:8080

The string will match and the auth headers will be set.