### PR TITLE
CIRC-3784 Check other path for cert

### DIFF
--- a/appliance-support/crashreporter/opt/napp/bin/backwash
+++ b/appliance-support/crashreporter/opt/napp/bin/backwash
@@ -19,7 +19,13 @@ fi
 echo "Invoking tracer against $PID."
 
 if [ -r /opt/napp/etc/ssl/appliance.crt ]; then
-    HOSTCN=`openssl x509 -in /opt/napp/etc/ssl/appliance.crt -subject | gawk -F'= ' '/^subject= (.+)/{print $2;}' | sed -e 's/.*CN=//g;' -e 's#/.*##g;'`
+    CERT=/opt/napp/etc/ssl/appliance.crt
+elif [ -r /opt/noit/prod/etc/ssl/appliance.crt ] ; then
+    CERT=/opt/noit/prod/etc/ssl/appliance.crt
+fi
+
+if [ "x$CERT" != "x" ]; then
+    HOSTCN=`openssl x509 -in $CERT -subject | gawk -F'= ' '/^subject= (.+)/{print $2;}' | sed -e 's/.*CN=//g;' -e 's#/.*##g;'`
 fi
 
 /opt/backtrace/bin/ptrace --print --config=/opt/noit/prod/etc/ptrace.conf \


### PR DESCRIPTION
Ensures we find the broker's cert in the path that is used for
the CAQL-broker deployment pattern in Circonus SaaS and on-prem.