### PR TITLE
CIRC-4023 watchdog config is not standalone

### DIFF
--- a/appliance-root/opt/noit/prod/etc/noit.conf
+++ b/appliance-root/opt/noit/prod/etc/noit.conf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf8" standalone="yes"?>
 <noit xmlns:reverse="noit://module/reverse" xmlns:custom="noit://module/custom" xmlns:histogram="noit://module/histogram" lockfile="/var/run/noitd.lock">
-  <include file="circonus-watchdog.conf" snippet="true"/>
+  <include file="circonus-watchdog.conf" snippet="true" readonly="true"/>
   <eventer>
     <config>
       <default_queue_threads>10</default_queue_threads>

--- a/appliance-support/crashreporter/opt/noit/prod/etc/circonus-watchdog.conf
+++ b/appliance-support/crashreporter/opt/noit/prod/etc/circonus-watchdog.conf
@@ -1,2 +1,2 @@
-<?xml version="1.0" encoding="utf8" standalone="yes"?>
+<?xml version="1.0" encoding="utf8"?>
 <watchdog glider="/opt/napp/bin/backwash" tracedir="/opt/noit/prod/traces"/>


### PR DESCRIPTION
It is included with `snippet="true"`.

Set the `readonly` attribute on the include of the watchdog config
so that it will not be modified during a config update, since it is
a packaged file.