### PR TITLE
Fix docker upgrades and volume interplay.

### DIFF
--- a/appliance-root/opt/napp/bin/broker-start
+++ b/appliance-root/opt/napp/bin/broker-start
@@ -10,7 +10,7 @@
 #   /opt/napp/package/circonus-field-broker-core-stock.deb
 #
 # This might not be the same one that was installed when these volumes
-# were created, so we just go ahead and for install it again and it will
+# were created, so we just go ahead and force-install it again and it will
 # replace configs that we have configured that way.
 # It's a quick (subsecond) install.
 ###

--- a/appliance-root/opt/napp/bin/broker-start
+++ b/appliance-root/opt/napp/bin/broker-start
@@ -3,7 +3,7 @@
 ###
 # In docker we want so support /opt/noit/prod/etc as a volume
 # However, this means when we roll new docker images and people upgrade
-# the will not get the updated package config files.  While noone has
+# they will not get the updated package config files.  While no one has
 # ever said anything nice about apt/dpkg, at least it knows which config
 # files are user-editable...  So, for the docker image we drop a copy of
 # the circonus-field-broker-core package we installed into

--- a/appliance-root/opt/napp/bin/broker-start
+++ b/appliance-root/opt/napp/bin/broker-start
@@ -1,11 +1,35 @@
 #!/bin/sh
 
+###
+# In docker we want so support /opt/noit/prod/etc as a volume
+# However, this means when we roll new docker images and people upgrade
+# the will not get the updated package config files.  While noone has
+# ever said anything nice about apt/dpkg, at least it knows which config
+# files are user-editable...  So, for the docker image we drop a copy of
+# the circonus-field-broker-core package we installed into
+#   /opt/napp/package/circonus-field-broker-core-stock.deb
+#
+# This might not be the same one that was installed when these volumes
+# were created, so we just go ahead and for install it again and it will
+# replace configs that we have configured that way.
+# It's a quick (subsecond) install.
+###
+if [ -r /opt/napp/package/circonus-field-broker-core-stock.deb ]; then
+  INSTALLED=`dpkg -l circonus-field-broker-core | awk '/broker-core/{print $2"-"$3}'`
+  REMEMBERED=`cat /opt/noit/prod/etc/docker-core-version 2>/dev/null`
+  if [ "$INSTALLED" != "$REMEMBERED" ]; then
+    echo "Updating config files..."
+    /usr/bin/apt-get install --reinstall /opt/napp/package/circonus-field-broker-core-stock.deb
+    /usr/bin/dpkg -l circonus-field-broker-core | \
+      awk '/broker-core/{print $2"-"$3}' > /opt/noit/prod/etc/docker-core-version
+  fi
+fi
+
 NOITD=/opt/noit/prod/sbin/noitd
 CONF=/opt/noit/prod/etc/noit.conf
 USER=broker
 GROUP=broker
 WRITE_PATHS=" \
-	/opt/napp/etc/ssl \
 	/opt/noit/prod/log \
 	/opt/noit/prod/etc \
 "

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,11 @@ RUN chmod 755 /bin/console && \
     apt-get install -y circonus-field-broker && \
     apt-get install -y --allow-unauthenticated circonus-field-broker-crashreporter && \
     apt-get install -y telnet && \
+    mkdir /opt/napp/package && \
+    /opt/circonus/bin/curl -o /opt/napp/package/circonus-field-broker-core-stock.deb http://pilot.circonus.net/ubuntu/pool/main/c/circonus-field-broker-core/`dpkg -l circonus-field-broker-core | awk '/broker-core/{print $2"-"$3"xenial_"$4".deb"}'` && \
+    /usr/bin/dpkg -l circonus-field-broker-core | \
+      awk '/broker-core/{print $2"-"$3}' > /opt/noit/prod/etc/docker-core-version && \
     rm -rf /var/lib/apt/lists/*
-RUN echo "MANAGED_CORONER=1" >> /opt/noit/prod/etc/noit.env
 VOLUME ["/opt/noit/prod/etc", "/opt/noit/prod/log"]
 
 # These are default ports, you almost certainly want to run this


### PR DESCRIPTION
If /opt/noit/prod/etc is a volume, we get the "original" installs
copy in there and it will never upgrade.  To work around that we
stash a copy of the deb used to install these files in /opt/napp/package
and if it doesn't match the version last used in the volume we force
a reinstall (which don't touch the user configs) and mark it as done.
This should happen once per upgrade.