### PR TITLE
CIRC-4638 - Add LMDB Path For Filtersets

### DIFF
--- a/appliance-root/opt/noit/prod/etc/noit.conf
+++ b/appliance-root/opt/noit/prod/etc/noit.conf
@@ -19,7 +19,7 @@
   </modules>
   <include file="circonus-listeners.conf" snippet="true" readonly="true"/>
   <checks priority_scheduling="true" max_initial_stutter="60000" filterset="default" backingstore="/opt/noit/prod/etc/checks" lmdb_path="/opt/noit/prod/etc/checks_lmdb"/>
-  <filtersets replication_prefix="circonus">
+  <filtersets replication_prefix="circonus" lmdb_path="/opt/noit/prod/etc/filtersets_lmdb">
     <include file="circonus-filtersets.conf" readonly="true"/>
     <circonus backingstore="/opt/noit/prod/etc/filtersets"/>
   </filtersets>


### PR DESCRIPTION
Add a default filterset path for LMDB filtersets. This requires setting
use_lmdb="true" to turn on for the first time - after that, it will be
based on directory existance