### PR TITLE
CIRC-4638 - Enable LMDB-Backed Broker Checks And Filters

### DIFF
--- a/appliance-root/opt/noit/prod/etc/noit.conf
+++ b/appliance-root/opt/noit/prod/etc/noit.conf
@@ -18,8 +18,8 @@
     <include file="circonus-modules.conf" readonly="true"/>
   </modules>
   <include file="circonus-listeners.conf" snippet="true" readonly="true"/>
-  <checks priority_scheduling="true" max_initial_stutter="60000" filterset="default" backingstore="/opt/noit/prod/etc/checks" lmdb_path="/opt/noit/prod/etc/checks_lmdb"/>
-  <filtersets replication_prefix="circonus" lmdb_path="/opt/noit/prod/etc/filtersets_lmdb">
+  <checks priority_scheduling="true" max_initial_stutter="60000" filterset="default" backingstore="/opt/noit/prod/etc/checks" lmdb_path="/opt/noit/prod/etc/checks_lmdb" use_lmdb="true"/>
+  <filtersets replication_prefix="circonus" lmdb_path="/opt/noit/prod/etc/filtersets_lmdb" use_lmdb="true">
     <include file="circonus-filtersets.conf" readonly="true"/>
     <circonus backingstore="/opt/noit/prod/etc/filtersets"/>
   </filtersets>


### PR DESCRIPTION
Change the default broker noit.conf file to set use_lmdb="true" for
checks and filters. This, once deployed, will convert anyone using this
file to using LMDB-backed checks and filters for their brokers.