### PR TITLE
CIRC-5762 Use different group credential on Ubuntu

### DIFF
--- a/appliance-root/opt/napp/bin/broker-start
+++ b/appliance-root/opt/napp/bin/broker-start
@@ -29,6 +29,14 @@ NOITD=/opt/noit/prod/sbin/noitd
 CONF=/opt/noit/prod/etc/noit.conf
 USER=broker
 GROUP=broker
+
+NOIT_EXTERNAL_GROUP=nobody
+
+# Ubuntu is different
+if [[ -f /etc/lsb-release ]]; then
+    NOIT_EXTERNAL_GROUP=nogroup
+fi
+
 WRITE_PATHS=" \
 	/opt/noit/prod/log \
 	/opt/noit/prod/etc \

--- a/appliance-root/opt/napp/bin/broker-start
+++ b/appliance-root/opt/napp/bin/broker-start
@@ -30,13 +30,6 @@ CONF=/opt/noit/prod/etc/noit.conf
 USER=broker
 GROUP=broker
 
-NOIT_EXTERNAL_GROUP=nobody
-
-# Ubuntu is different
-if [[ -f /etc/lsb-release ]]; then
-    NOIT_EXTERNAL_GROUP=nogroup
-fi
-
 WRITE_PATHS=" \
 	/opt/noit/prod/log \
 	/opt/noit/prod/etc \
@@ -55,6 +48,14 @@ else
 fi
 
 set -o allexport
+
+NOIT_EXTERNAL_GROUP=nobody
+
+# Ubuntu is different
+if [ -f /etc/lsb-release ]; then
+    NOIT_EXTERNAL_GROUP=nogroup
+fi
+
 # File containing software build info
 # Do not modify this file.
 if [ -r /opt/noit/prod/etc/noit.env ]; then

--- a/appliance-root/opt/napp/bin/broker-start
+++ b/appliance-root/opt/napp/bin/broker-start
@@ -29,7 +29,6 @@ NOITD=/opt/noit/prod/sbin/noitd
 CONF=/opt/noit/prod/etc/noit.conf
 USER=broker
 GROUP=broker
-
 WRITE_PATHS=" \
 	/opt/noit/prod/log \
 	/opt/noit/prod/etc \

--- a/appliance-root/opt/noit/prod/etc/circonus-modules-enterprise.conf
+++ b/appliance-root/opt/noit/prod/etc/circonus-modules-enterprise.conf
@@ -15,7 +15,7 @@
 <module image="external" name="external">
   <config>
     <user>nobody</user>
-    <group>nobody</group>
+    <group>ENV:nobody:{NOIT_EXTERNAL_GROUP}</group>
     <path>/opt/noit/prod/libexec/external-plugins/</path>
     <nagios_regex>\'?(?&lt;key&gt;[^'=\s]+)\'?=(?&lt;value&gt;-?[0-9]+(\.[0-9]+)?)(?&lt;uom&gt;[a-zA-Z%]+)?(?=[;,\s])</nagios_regex>
   </config>


### PR DESCRIPTION
External module configuration will get the correct group name from
environment. The start script will set it appropriately.