### PR TITLE
CIRC-6129 Default to crash reporting

### DIFF
--- a/appliance-root/opt/noit/prod/etc/noit.local.env
+++ b/appliance-root/opt/noit/prod/etc/noit.local.env
@@ -87,6 +87,6 @@
 ## Crash Reporting Disablement
 ## By default, crash reports are uploaded to Circonus.
 ## Setting to any non-empty value will disable crash reporting.
-## https://docs.circonus.com/circonus/administration/enterprise-brokers/#troubleshooting
+## https://docs.circonus.com/circonus/administration/enterprise-brokers/#automated-crash-reporting
 #
 #DISABLE_CRASH_REPORTS=""

--- a/appliance-root/opt/noit/prod/etc/noit.local.env
+++ b/appliance-root/opt/noit/prod/etc/noit.local.env
@@ -84,3 +84,9 @@
 #
 #NOIT_MODULES="<pcre-pattern>"
 
+## Crash Reporting Disablement
+## By default, crash reports are uploaded to Circonus.
+## Setting to any non-empty value will disable crash reporting.
+## https://docs.circonus.com/circonus/administration/enterprise-brokers/#troubleshooting
+#
+#DISABLE_CRASH_REPORTS=""

--- a/appliance-support/crashreporter/opt/napp/bin/backwash
+++ b/appliance-support/crashreporter/opt/napp/bin/backwash
@@ -2,29 +2,29 @@
 PID=$1
 REASON=$2
 
-if [ -r /opt/noit/prod/etc/noit.env ]; then
+if [[ -r /opt/noit/prod/etc/noit.env ]]; then
     . /opt/noit/prod/etc/noit.env
 fi
-if [ -r /opt/noit/prod/etc/noit.local.env ]; then
+if [[ -r /opt/noit/prod/etc/noit.local.env ]]; then
     . /opt/noit/prod/etc/noit.local.env
 fi
 
-if [ ! -x /opt/backtrace/bin/ptrace ]; then
+if [[ -n $DISABLE_CRASH_REPORTS || ! -x /opt/backtrace/bin/ptrace ]]; then
     echo "Process $PID has crashed."
     echo "Noit version: $NOIT_VERSION"
-    echo "No tracer installed."
+    echo "No tracer installed or crash reporting disabled."
     exit
 fi
 
 echo "Invoking tracer against $PID."
 
-if [ -r /opt/napp/etc/ssl/appliance.crt ]; then
+if [[ -r /opt/napp/etc/ssl/appliance.crt ]]; then
     CERT=/opt/napp/etc/ssl/appliance.crt
-elif [ -r /opt/noit/prod/etc/ssl/appliance.crt ] ; then
+elif [[ -r /opt/noit/prod/etc/ssl/appliance.crt ]] ; then
     CERT=/opt/noit/prod/etc/ssl/appliance.crt
 fi
 
-if [ "x$CERT" != "x" ]; then
+if [[ "x$CERT" != "x" ]]; then
     HOSTCN=`openssl x509 -in $CERT -subject | gawk -F'= ' '/^subject= (.+)/{print $2;}' | sed -e 's/.*CN=//g;' -e 's#/.*##g;'`
 fi
 
@@ -38,3 +38,6 @@ MOD_HTTP_OBSERVER_FLAGS="--load=/opt/circonus/libexec/mtev/http_observer.so --gl
     $MOD_HTTP_OBSERVER_FLAGS \
     $PID
 
+# Clean up unsent traces older than 7 days
+tracedir="/opt/noit/prod/traces"
+find $tracedir -type f -name '*.btt' -mtime +7 | xargs rm -f


### PR DESCRIPTION
Define an env var for disabling reports.

Add cleanup step to glider, in case reporting is enabled but uploads
are not possible.