### PR TITLE
Update TLS settings on default listener

### DIFF
--- a/appliance-root/opt/noit/prod/etc/circonus-listeners-site.conf
+++ b/appliance-root/opt/noit/prod/etc/circonus-listeners-site.conf
@@ -19,13 +19,13 @@
   follow it in this file.
 
   The following sample config starts a listener on port 43201,
-  permits SSLv3 to be used, lets the client choose the preferred
+  permits TLS 1.0/1.1 to be used, lets the client choose the preferred
   cipher, and allows all "HIGH"-grade ciphers.  It uses the same
   key and certificate as the default 43191 listener.
 -->
 <!--
   <sslconfig>
-    <layer>tlsv1:all,!sslv2</layer>
+    <layer>tlsv1:all,!sslv3,!sslv2</layer>
     <ciphers>HIGH</ciphers>
   </sslconfig>
   <listener type="control_dispatch" address="*" port="43201" ssl="on">

--- a/appliance-root/opt/noit/prod/etc/circonus-listeners.conf
+++ b/appliance-root/opt/noit/prod/etc/circonus-listeners.conf
@@ -5,8 +5,9 @@
     <certificate_file>/opt/noit/prod/etc/ssl/appliance.crt</certificate_file>
     <key_file>/opt/noit/prod/etc/ssl/appliance.key</key_file>
     <ca_chain>/opt/noit/prod/etc/ssl/ca.crt</ca_chain>
-    <layer>tlsv1:all,!sslv2,!sslv3,cipher_server_preference</layer>
-    <ciphers>EECDH+AES128+AESGCM:EECDH+AES256+AESGCM:EECDH+AES128+SHA:EECDH+AES256+SHA:EECDH+AES128+SHA256:EECDH+AES256+SHA384:EDH+AES128+AESGCM:EDH+AES256+AESGCM:EDH+AES128+SHA:EDH+AES256+SHA:AES128-SHA:!DSS</ciphers>
+    <layer_openssl_10>tlsv1.2</layer_openssl_10>
+    <layer_openssl_11>tlsv1:all,>=tlsv1.2,cipher_server_preference</layer_openssl_11>
+    <ciphers>ECDHE+AES128+AESGCM:ECDHE+AES256+AESGCM:DHE+AES128+AESGCM:DHE+AES256+AESGCM:!DSS</ciphers>
   </sslconfig>
   <consoles type="noit_console">
     <listener address="/tmp/noit">


### PR DESCRIPTION
Permit only TLS 1.2 and later, and reduce the cipher set to GCM
suites, which have higher performance. The vast majority of clients
are already using GCM ciphers, and with the removal of older protocol
versions, there is no need to support less secure/performant ciphers.

Update example in listener site config to reflect re-enabling older
TLS versions for an alternate port, as that is the most likely scenario.