### PR TITLE
CIRC-9361 Reenable httptrap fanout

### DIFF
--- a/appliance-root/opt/noit/prod/etc/circonus-modules-enterprise.conf
+++ b/appliance-root/opt/noit/prod/etc/circonus-modules-enterprise.conf
@@ -10,7 +10,6 @@
 <module image="httptrap" name="httptrap">
   <config>
     <surrogate>true</surrogate>
-    <fanout>off</fanout>
   </config>
 </module>
 <module image="external" name="external">


### PR DESCRIPTION
Reverts the change from #63 now that we've made fixes that allow it to be stable.